### PR TITLE
Spell out installation steps to avoid confusion

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,10 @@ Getting started
 ===============
 
 Just clone this repository, run the install.sh script and follow the on screen instructions. This script should run on most modern linux distributions. Post to the Developer Community if you run into any problems here.
+```
+git clone https://github.com/FriendSoftwareLabs/friendup
+friendup/install.sh
+```
 
 Default login
 -------------


### PR DESCRIPTION
install.sh will fail if it's not executed from the directory *above*
This is due to a hardcoded `cd friendup` in the script.
This also means that the code *must* be checked out into a directory
named 'friendup'.

The two commands added to the instructions accomplish this.

(In addition, my editor seems to have added a newline, which is good POSIX style and shouldn't hurt.)